### PR TITLE
Fix for file paths with utf8 characters

### DIFF
--- a/git-archive-all
+++ b/git-archive-all
@@ -148,7 +148,7 @@ class GitArchiver(object):
 if __name__ == "__main__":
     from optparse import OptionParser
 
-    parser = OptionParser(usage="usage: %prog [-v] [--prefix PREFIX] [--no-exclude] OUTPUT_FILE", version="%prog 1.2")
+    parser = OptionParser(usage="usage: %prog [-v] [--prefix PREFIX] [--no-exclude] OUTPUT_FILE", version="%prog 1.3")
     
     parser.add_option('--prefix', type='string', dest='prefix', 
                       default='', help="prepend PREFIX to each filename in the archive")


### PR DESCRIPTION
- git list files with utf8 characters as escaped strings and with
  additional quotes. For example:
  
     (...)
     sounds/Parametr.ogg
     "sounds/Urz\304\205dzenie.ogg"
     sounds/Alarm.ogg
     (...)
