### PR TITLE
Enable tarbomb if --prefix '' specified

### DIFF
--- a/git-archive-all
+++ b/git-archive-all
@@ -428,7 +428,7 @@ if __name__ == '__main__':
     parser.add_option('--prefix',
                       type='string',
                       dest='prefix',
-                      default='',
+                      default=None,
                       help="prepend PREFIX to each filename in the archive. OUTPUT_FILE name is used by default to avoid tarbomb")
 
     parser.add_option('-v', '--verbose',
@@ -469,7 +469,7 @@ if __name__ == '__main__':
         parser.error("You cannot use directory as output")
 
     # avoid tarbomb
-    if options.prefix:
+    if options.prefix is not None:
         options.prefix = path.join(options.prefix, '')
     else:
         import re


### PR DESCRIPTION
Sometimes it's necessary to make a tarbomb, for example with Amazon Elastic Beanstalk they expect a zip file where the top level of the archive has a `.ebextensions` directory. This pull request enables specifying `--prefix ''` by using `None` as a sentinel value to mean "unspecified", so that empty string is distinct.
