### PR TITLE
Submodule files matching top level directory names were excluded.

### DIFF
--- a/git-archive-all
+++ b/git-archive-all
@@ -270,12 +270,11 @@ class GitArchiver(object):
             # Git puts path in quotes if file path has unicode characters.
             repo_file_path = repo_file_path.strip('"')  # file path relative to current repo
             file_name = path.basename(repo_file_path)
+            main_repo_file_path = path.join(repo_path, repo_file_path)  # file path relative to the main repo
 
             # Only list symlinks and files that don't start with git.
-            if file_name.startswith(".git") or (not path.islink(repo_file_path) and path.isdir(repo_file_path)):
+            if file_name.startswith(".git") or (not path.islink(main_repo_file_path) and path.isdir(main_repo_file_path)):
                 continue
-
-            main_repo_file_path = path.join(repo_path, repo_file_path)  # file path relative to the main repo
 
             if self.is_file_excluded(repo_abspath, repo_file_path, exclude_patterns):
                 continue


### PR DESCRIPTION
This patch uses the relative paths from base git directory for these file test operations, instead of the raw filenames which may correspond to a directory.
(eg. I actually had this repo - git-archive-all - as a submodule, it was excluding the core python file.)

I considered moving the logic to is_file_excluded, but went in favor of keeping the pull request small and fixing only the issue at hand.