### PR TITLE
Remove implicit exclusion of files starting with “.git”

### DIFF
--- a/git_archive_all.py
+++ b/git_archive_all.py
@@ -306,10 +306,8 @@ class GitArchiver(object):
             file_name = path.basename(repo_file_path)
             main_repo_file_path = path.join(repo_path, repo_file_path)  # file path relative to the main repo
 
-            # Only list symlinks and files that don't start with git.
-            if file_name.startswith(".git") or (
-                not path.islink(main_repo_file_path) and path.isdir(main_repo_file_path)
-            ):
+            # Only list symlinks and files.
+            if not path.islink(main_repo_file_path) and path.isdir(main_repo_file_path):
                 continue
 
             if self.is_file_excluded(repo_abspath, repo_file_path, exclude_patterns):


### PR DESCRIPTION
I'm opening this request as both a suggestion and a question as to why you're unconditionally removing all files starting with `.git` even with `--no-exclude` flag?  One of our customers complained that this was happening, and we found that he was correct that this behavior deviates from `git archive`.

This PR is to remove the unconditional exclusion of `.git*` files and allow the user to keep or remove these files manually via `.gitattributes`.  This behavior will closer match `git archive`.

