### PR TITLE
drop shebang from non-executable file

### DIFF
--- a/git_archive_all.py
+++ b/git_archive_all.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 # coding=utf-8
 
 # The MIT License (MIT)


### PR DESCRIPTION
it doesn't make any sense to have shebang in non-executable file.