### PR TITLE
Check submodules for excludes

### DIFF
--- a/git_archive_all.py
+++ b/git_archive_all.py
@@ -332,6 +332,9 @@ class GitArchiver(object):
                         continue
 
                     for submodule_file_path in self.walk_git_files(submodule_path):
+                        if self.is_file_excluded(repo_abspath, submodule_file_path, exclude_patterns):
+                            continue
+
                         yield submodule_file_path
         except IOError:
             pass

--- a/git_archive_all.py
+++ b/git_archive_all.py
@@ -328,6 +328,9 @@ class GitArchiver(object):
                     submodule_path = m.group(1)
                     submodule_path = path.join(repo_path, submodule_path)
 
+                    if self.is_file_excluded(repo_abspath, submodule_path, exclude_patterns):
+                        continue
+
                     for submodule_file_path in self.walk_git_files(submodule_path):
                         yield submodule_file_path
         except IOError:


### PR DESCRIPTION
If a submodule's path is excluded via `.gitattributes`, `git archive` will not include this file. However, `git archive-all` does. This patch fixes this behavior by checking submodules against the exclude list.