### PR TITLE
Fixed fail of "git check-attr" file path

### DIFF
--- a/git_archive_all.py
+++ b/git_archive_all.py
@@ -174,7 +174,7 @@ class GitArchiver(object):
         @rtype: bool
         """
         out = self.run_git_shell(
-            'git check-attr -z export-ignore -- %s' % repo_file_path,
+            'git check-attr -z export-ignore -- \"%s\"' % repo_file_path,
             cwd=repo_abspath
         ).split('\0')
 


### PR DESCRIPTION
When filename contains brackets or apostrophes:
```
Jonh's test.txt
Old test (check later).txt
```

the "git check-attr" command fails and stops the whole process
```
/bin/sh: 1: Syntax error: "(" unexpected
```

The fix is simple and easy - use quotes on file path.