### PR TITLE
Fix zip format recognition

### DIFF
--- a/git_archive_all.py
+++ b/git_archive_all.py
@@ -72,7 +72,7 @@ class GitArchiver(object):
         'gz': 'w:gz',
         'xz': 'w:xz'
     }
-    ZIPFILE_FORMATS = ('.zip',)
+    ZIPFILE_FORMATS = ('zip',)
 
     LOG = logging.getLogger('GitArchiver')
 


### PR DESCRIPTION
Changes introduced by commit dc84afd7f10b7a8eca7bc7637d87f147a1eb66e4
("Fix tbz2 format was not recognized" - 20.09.2018) broke zip format recognintion.

File extension returned by os.path.splitext() is 'zip', not '.zip'

Before breaking changes extension checking code looked like "if output_format == 'zip':" (without dot)