### PR TITLE
Fix a couple of issues on Windows host

### DIFF
--- a/git_archive_all.py
+++ b/git_archive_all.py
@@ -474,7 +474,7 @@ class GitArchiver(object):
             return None
 
         try:
-            return tuple(int(v) for v in version.split('.'))
+            return tuple(int(v) if v.isdigit() else 0 for v in version.split('.'))
         except ValueError:
             cls.LOG.warning("Unable to parse Git version \"%s\".", version)
             return None

--- a/git_archive_all.py
+++ b/git_archive_all.py
@@ -422,7 +422,7 @@ class GitArchiver(object):
 
         @rtype: str
         """
-        return output.decode('unicode_escape').encode('raw_unicode_escape').decode('utf-8')
+        return '\\'.join(s.decode('unicode_escape').encode('raw_unicode_escape').decode('utf-8') for s in output.split(b'\\'))
 
     @classmethod
     def run_git_shell(cls, cmd, cwd=None):


### PR DESCRIPTION
Tested on Windows 7 x64 with Python 3.7.2 64-bit and GitHub Desktop environment (MSYS).

One problem is the Git version string, that contains some text and not only digits, leading to this error message:

> Unable to parse Git version "2.14.1.windows.1".

The fix replaces any non-digit segment with 0.

The other problem is that the file paths contain backslashes on Windows, which are not handled correctly by Python codec. I'm not sure but there might be an issue on Linux too, if the backslash is used in some file name.

The fix first removes any backslash and process each segment separately, then joins the output putting back the backslashes.