### PR TITLE
Optionally specify the main git repository

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,7 @@ Archive repository with all its submodules.
 
       --prefix=PREFIX       Prepend PREFIX to each filename in the archive. OUTPUT_FILE name is used by default to avoid tarbomb. You can set it to '' in order to explicitly request tarbomb.
 
+      -C BASE_REPO          Use BASE_REPO as the main repository git working directory to archive.  Defaults to current directory when empty
       --no-exclude          Don't read .gitattributes files for patterns containing export-ignore attributes.
 
       --force-submodules    Force a `git submodule init && git submodule update` at each level before iterating submodules

--- a/git_archive_all.py
+++ b/git_archive_all.py
@@ -480,7 +480,10 @@ class GitArchiver(object):
             return None
 
 
-def main():
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv
+
     from optparse import OptionParser, SUPPRESS_HELP
 
     parser = OptionParser(
@@ -538,7 +541,7 @@ def main():
                           dest='compresslevel',
                           help=SUPPRESS_HELP)
 
-    options, args = parser.parse_args()
+    options, args = parser.parse_args(argv[1:])
 
     if len(args) != 1:
         parser.error("You must specify exactly one output file")
@@ -575,8 +578,8 @@ def main():
     except Exception as e:
         parser.exit(2, "{0}\n".format(e))
 
-    sys.exit(0)
+    return 0
 
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())

--- a/git_archive_all.py
+++ b/git_archive_all.py
@@ -484,8 +484,8 @@ def main():
     from optparse import OptionParser, SUPPRESS_HELP
 
     parser = OptionParser(
-        usage="usage: %prog [-v] [--prefix PREFIX] [--no-exclude] [--force-submodules]"
-              " [--extra EXTRA1 ...] [--dry-run] [-0 | ... | -9] OUTPUT_FILE",
+        usage="usage: %prog [-v] [-C BASE_REPO] [--prefix PREFIX] [--no-exclude]"
+              " [--force-submodules] [--extra EXTRA1 ...] [--dry-run] [-0 | ... | -9] OUTPUT_FILE",
         version="%prog {0}".format(__version__)
     )
 
@@ -496,6 +496,13 @@ def main():
                       help="""prepend PREFIX to each filename in the archive.
                           OUTPUT_FILE name is used by default to avoid tarbomb.
                           You can set it to '' in order to explicitly request tarbomb""")
+
+    parser.add_option('-C',
+                      type='string',
+                      dest='base_repo',
+                      default=None,
+                      help="""use BASE_REPO as the main repository git working directory to archive.
+                           Defaults to current directory when empty""")
 
     parser.add_option('-v', '--verbose',
                       action='store_true',
@@ -561,7 +568,9 @@ def main():
         archiver = GitArchiver(options.prefix,
                                options.exclude,
                                options.force_sub,
-                               options.extra)
+                               options.extra,
+                               path.abspath(options.base_repo) if options.base_repo is not None else None
+                               )
         archiver.create(output_file_path, options.dry_run, compresslevel=options.compresslevel)
     except Exception as e:
         parser.exit(2, "{0}\n".format(e))


### PR DESCRIPTION
Follows git's convention for option naming.

The use case was to add extra files to the archive from an external directory, in cases where the main directory is not user-writeable.